### PR TITLE
Don't apply monthly account credits during summer months

### DIFF
--- a/app/controllers/Accounting.java
+++ b/app/controllers/Accounting.java
@@ -165,6 +165,10 @@ public class Accounting extends Controller {
         c.set(Calendar.SECOND, 0);
         c.set(Calendar.MILLISECOND, 0);
         Date monthStartDate = c.getTime();
+        int month = c.get(Calendar.MONTH) + 1;
+
+        // no credits in the months of July and August
+        if (month == 7 || month == 8) return;
 
         List<Account> accounts = Account.allWithMonthlyCredits().stream()
             .filter(a -> a.date_last_monthly_credit == null || a.date_last_monthly_credit.before(monthStartDate))


### PR DESCRIPTION
Here's a small fix I need going into the summer. I don't want our accounts getting automatically credited during July or August. I understand that different schools might have different summer months, or might have different summer preferences, but we can climb that mountain when we reach it.