### PR TITLE
Case references updates

### DIFF
--- a/app/assets/javascripts/edit_minutes.js
+++ b/app/assets/javascripts/edit_minutes.js
@@ -101,13 +101,13 @@ function Charge(charge_id, el) {
 
             if (json.resolution_plan === time_served_string) {
                 el.find(".rp-followup-time-served").prop("checked", true);
-                el.find(".rp-row").hide();
+                el.find(".resolution_plan").hide();
                 el.find(".original-res-plan-text").addClass("deleted");
             } else if (json.resolution_plan) {
                 el.find(".rp-followup-new-rp").prop("checked", true);
                 el.find(".original-res-plan-text").addClass("deleted");
             } else {
-                el.find(".rp-row").hide();
+                el.find(".resolution_plan").hide();
             }
         }
 
@@ -248,10 +248,9 @@ function Charge(charge_id, el) {
 
     el.find(".rp-followup").change(function() {
         if ($(this).hasClass("rp-followup-new-rp")) {
-            el.find(".rp-row").show();
+            el.find(".resolution_plan").show();
         } else {
-            el.find(".rp-row").hide();
-            el.find(".resolution_plan").val("");
+            el.find(".resolution_plan").hide().val("");
         }
         el.find(".original-res-plan-text").addClass("deleted");
         self.markAsModified();

--- a/app/assets/javascripts/edit_minutes.js
+++ b/app/assets/javascripts/edit_minutes.js
@@ -102,8 +102,10 @@ function Charge(charge_id, el) {
             if (json.resolution_plan === time_served_string) {
                 el.find(".rp-followup-time-served").prop("checked", true);
                 el.find(".rp-row").hide();
+                el.find(".original-res-plan-text").addClass("deleted");
             } else if (json.resolution_plan) {
                 el.find(".rp-followup-new-rp").prop("checked", true);
+                el.find(".original-res-plan-text").addClass("deleted");
             } else {
                 el.find(".rp-row").hide();
             }
@@ -251,6 +253,7 @@ function Charge(charge_id, el) {
             el.find(".rp-row").hide();
             el.find(".resolution_plan").val("");
         }
+        el.find(".original-res-plan-text").addClass("deleted");
         self.markAsModified();
     });
 

--- a/app/assets/stylesheets/main.less
+++ b/app/assets/stylesheets/main.less
@@ -329,6 +329,11 @@ img.x {
   padding-left: 5px;
 }
 
+.original-res-plan-text.deleted {
+  color: #d00;
+  text-decoration: line-through;
+}
+
 #sidebar
 {
     position: fixed;
@@ -763,11 +768,6 @@ input.date {
 
 .code-__partial, .partial-days {
   background: #deeff8;
-}
-
-.original-res-plan-note {
-  font-style: italic;
-  color: #999;
 }
 
 /***************************************************************************

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -14,6 +14,7 @@ import org.xhtmlrenderer.pdf.ITextRenderer;
 
 import com.avaje.ebean.Ebean;
 import com.avaje.ebean.Expr;
+import com.avaje.ebean.ExpressionList;
 import com.avaje.ebean.FetchConfig;
 import com.avaje.ebean.SqlQuery;
 import com.avaje.ebean.SqlRow;
@@ -898,11 +899,13 @@ public class Application extends Controller {
         return Json.stringify(Json.toJson(result));
     }
 
-    public static String jsonRules(String term) {
-        term = term.toLowerCase();
+    public static String jsonRules(Boolean includeBreakingResPlan) {
 
-        List<Entry> rules = Entry.find.where()
-            .eq("section.chapter.organization", Organization.getByHost())
+        ExpressionList expr = Entry.find.where().eq("section.chapter.organization", Organization.getByHost());
+        if (!includeBreakingResPlan) {
+            expr = expr.eq("is_breaking_res_plan", false);
+        }
+        List<Entry> rules = expr
             .eq("deleted", false)
             .eq("section.deleted", false)
             .eq("section.chapter.deleted", false)
@@ -910,12 +913,10 @@ public class Application extends Controller {
 
         List<Map<String, String> > result = new ArrayList<Map<String, String> > ();
         for (Entry r : rules) {
-            if (r.title.toLowerCase().contains(term)) {
-                HashMap<String, String> values = new HashMap<String, String>();
-                values.put("label", r.getNumber() + " " + r.title);
-                values.put("id", "" + r.id);
-                result.add(values);
-            }
+            HashMap<String, String> values = new HashMap<String, String>();
+            values.put("label", r.getNumber() + " " + r.title);
+            values.put("id", "" + r.id);
+            result.add(values);
         }
 
         return Json.stringify(Json.toJson(result));

--- a/app/models/Case.java
+++ b/app/models/Case.java
@@ -373,6 +373,9 @@ public class Case extends Model implements Comparable<Case> {
         if (charge.sm_decision != null && !charge.sm_decision.isEmpty()) {
             return charge.sm_decision;
         }
+        if (charge.referred_to_sm && charge.resolution_plan.isEmpty()) {
+            return "[Referred to School Meeting]";
+        }
         return charge.resolution_plan;
     }
 }

--- a/app/models/Case.java
+++ b/app/models/Case.java
@@ -332,6 +332,9 @@ public class Case extends Model implements Comparable<Case> {
         if (!result.isEmpty()) {
             result += " Then per case " + case_number + ", ";
         }
+        if (findings.isEmpty()) {
+            findings = "the " + OrgConfig.get().str_res_plan + " was not completed.";
+        }
         result += findings;
         return result;
     }

--- a/app/models/Case.java
+++ b/app/models/Case.java
@@ -275,9 +275,13 @@ public class Case extends Model implements Comparable<Case> {
             if (used_cases.contains(c)) {
                 continue;
             }
-            ArrayList<Case> case_referenced_cases = new ArrayList<Case>(c.referenced_cases);
-            case_referenced_cases.removeAll(used_cases);
-            if (case_referenced_cases.size() == 0) {
+            if (!isCaseRelevant(c, relevant_charges)) {
+                continue;
+            }
+            ArrayList<Case> _used_cases = new ArrayList<Case>(used_cases);
+            boolean hasRelevantReferences = c.referenced_cases.stream()
+                .anyMatch(rc -> isCaseRelevant(rc, relevant_charges) && !_used_cases.contains(rc));
+            if (!hasRelevantReferences) {
                 if (result.isEmpty()) {
                     result += "Per case ";
                 } else {
@@ -292,7 +296,7 @@ public class Case extends Model implements Comparable<Case> {
             if (!result.endsWith(".")) {
                 result += ".";
             }
-            Map<String, List<Charge>> groups = groupChargesByRuleAndResolutionPlan(c, relevant_charges);
+            Map<String, List<Charge>> groups = groupChargesByRuleAndResolutionPlan(findRelevantCharges(c, relevant_charges));
             for (Map.Entry<String, List<Charge>> entry : groups.entrySet()) {
                 List<Charge> group = entry.getValue();
                 result += " " + group.get(0).person.getDisplayName();
@@ -339,7 +343,7 @@ public class Case extends Model implements Comparable<Case> {
         return result;
     }
 
-    private static Map<String, List<Charge>> groupChargesByRuleAndResolutionPlan(Case c, List<Charge> relevant_charges) {
+    private static List<Charge> findRelevantCharges(Case c, List<Charge> relevant_charges) {
 
         List<Charge> charges =
             Charge.find
@@ -354,7 +358,15 @@ public class Case extends Model implements Comparable<Case> {
 
         return charges.stream()
             .filter(ch -> relevant_charges == null || relevant_charges.contains(ch))
-            .collect(Collectors.groupingBy(ch -> ch.getRuleTitle() + getResolutionPlanForCompositeFindings(ch)));
+            .collect(Collectors.toList());
+    }
+
+    private static Map<String, List<Charge>> groupChargesByRuleAndResolutionPlan(List<Charge> charges) {
+        return charges.stream().collect(Collectors.groupingBy(ch -> ch.getRuleTitle() + getResolutionPlanForCompositeFindings(ch)));
+    }
+
+    private static boolean isCaseRelevant(Case c, List<Charge> relevant_charges) {
+        return c.charges.stream().anyMatch(ch -> relevant_charges == null || relevant_charges.contains(ch));
     }
 
     private static String getResolutionPlanForCompositeFindings(Charge charge) {

--- a/app/models/CaseReference.java
+++ b/app/models/CaseReference.java
@@ -38,6 +38,10 @@ public class CaseReference {
 					cr.resolution_plan = charge.sm_decision;
 				}
 
+				if (charge.referred_to_sm && cr.resolution_plan.isEmpty()) {
+					cr.resolution_plan = "[Referred to School Meeting]";
+				}
+
 				for (Charge new_charge : referencing_case.charges) {
 					if (new_charge.referenced_charge == charge) {
 						cr.has_generated = true;

--- a/app/models/Charge.java
+++ b/app/models/Charge.java
@@ -85,6 +85,7 @@ public class Charge extends Model implements Comparable<Charge> {
         result.person = referenced_charge.person;
         result.rule = Entry.findBreakingResPlanEntry();
         result.referenced_charge = referenced_charge;
+        result.referred_to_sm = referenced_charge.referred_to_sm && referenced_charge.sm_decision == null;
         result.save();
         return result;
     }

--- a/app/views/edit_minutes.scala.html
+++ b/app/views/edit_minutes.scala.html
@@ -188,7 +188,7 @@ $(function () {
             </div>
             <div class="radio-inline">
               <label><input type="radio" class="rp-followup rp-followup-new-rp">
-                <span>Delete & replace @OrgConfig.get().str_res_plan</span></label>
+                <span>Delete & replace original @OrgConfig.get().str_res_plan</span></label>
             </div>
         </div>
         <div class="rp-row">

--- a/app/views/edit_minutes.scala.html
+++ b/app/views/edit_minutes.scala.html
@@ -176,7 +176,6 @@ $(function () {
     <td class="esm-form-label">Original:</td>
     <td colspan="2">
         <span class="original-res-plan-text"></span>
-        <span class="original-res-plan-note">(Note: This charge nullifies this original @(OrgConfig.get().str_res_plan).)</span>
     </td>
 </tr>
 <tr>
@@ -189,7 +188,7 @@ $(function () {
             </div>
             <div class="radio-inline">
               <label><input type="radio" class="rp-followup rp-followup-new-rp">
-                <span>Replace @OrgConfig.get().str_res_plan</span></label>
+                <span>Delete & replace @OrgConfig.get().str_res_plan</span></label>
             </div>
         </div>
         <div class="rp-row">

--- a/app/views/edit_minutes.scala.html
+++ b/app/views/edit_minutes.scala.html
@@ -24,7 +24,7 @@ app.ROLE_TESTIFIER = @PersonAtCase.ROLE_TESTIFIER
 app.ROLE_WRITER = @PersonAtCase.ROLE_WRITER
 
 app.people = @Html(Application.jcPeople(""))
-app.rules = @Html(Application.jsonRules(""))
+app.rules = @Html(Application.jsonRules(false))
 app.cases = @Html(Application.jsonCases(""))
 
 app.initial_data = {

--- a/app/views/view_settings.scala.html
+++ b/app/views/view_settings.scala.html
@@ -64,7 +64,7 @@ $(function () {
         $('#breaking-res-plan-entry-chooser'),
         false,
         2,
-        @Html(Application.jsonRules("")),
+        @Html(Application.jsonRules(true)),
         function(json) { return json.title; },
         null,
         null,


### PR DESCRIPTION
Some updates to fix issues we've been having with case references:
1. If a "breaking sentence" rule is set in the settings, that rule may not be assigned to a charge manually (using the rule chooser), but may only be assigned by pressing the "generate charge" button. This eliminates the issue of people forgetting to generate charges and incorrectly creating them manually.
2. If user leaves findings blank when processing a breaking sentence case (which happens) this is interpreted to mean "the sentence was not completed" and this text is inserted into the generated composite findings.
3. When user chooses "time served" or "replace sentence", the original sentence text becomes stylized as red strikethrough, to emphasize that the original sentence is being deleted.
4. The text "replace sentence" has become "delete & replace original sentence".
5. Fixed a bug which caused irrelevant cases to be included in the generated composite findings.
6. If a charge is referred to SM and that charge is referenced by a new charge before SM happens, the new charge will automatically be marked as referred to SM.
7. Previously, the prior charges would not be shown until "replace sentence" was selected. This has been fixed.