### PR TITLE
People bugfix

### DIFF
--- a/app/controllers/Accounting.java
+++ b/app/controllers/Accounting.java
@@ -165,7 +165,10 @@ public class Accounting extends Controller {
 
     public static String accountsJson() {
         List<Map<String, String>> result = new ArrayList<Map<String, String>>();
-        for (Account a : Account.all()) {
+        List<Account> accounts = new ArrayList<Account>();
+        accounts.addAll(Account.allPersonalChecking());
+        accounts.addAll(Account.allInstitutionalChecking());
+        for (Account a : accounts) {
             HashMap<String, String> values = new HashMap<String, String>();
             values.put("label", a.getName());
             values.put("id", "" + a.id);

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -88,9 +88,17 @@ public class Application extends Controller {
         return ok(views.html.view_sm_decisions.render(the_charges));
     }
 
-    public static List<Person> allPeople() {
+    public static List<Person> jcPeople() {
+        return peopleByTagType("show_in_jc");
+    }
+
+    public static List<Person> attendancePeople() {
+        return peopleByTagType("show_in_attendance");
+    }
+
+    private static List<Person> peopleByTagType(String tag_type) {
         List<Tag> tags = Tag.find.where()
-            .eq("show_in_jc", true)
+            .eq(tag_type, true)
             .eq("organization", Organization.getByHost())
             .findList();
 
@@ -855,7 +863,7 @@ public class Application extends Controller {
             }
         }
 
-        result.uncharged_people = allPeople();
+        result.uncharged_people = jcPeople();
         for (Map.Entry<Person, WeeklyStats.PersonCounts> entry : result.person_counts.entrySet()) {
             if (entry.getValue().this_period > 0) {
                 result.uncharged_people.remove(entry.getKey());
@@ -881,7 +889,7 @@ public class Application extends Controller {
     }
 
     public static String jcPeople(String term) {
-        List<Person> people = allPeople();
+        List<Person> people = jcPeople();
         Collections.sort(people, Person.SORT_DISPLAY_NAME);
 
         term = term.toLowerCase();

--- a/app/controllers/Attendance.java
+++ b/app/controllers/Attendance.java
@@ -95,7 +95,7 @@ public class Attendance extends Controller {
 
         return views.html.attendance_index.render(
                 all_people, person_to_stats, all_codes, codes_map,
-                Application.allPeople(), start_date, prev_date, next_date).toString();
+                Application.attendancePeople(), start_date, prev_date, next_date).toString();
     }
 
     public Result index(String start_date) {
@@ -187,7 +187,7 @@ public class Attendance extends Controller {
                 person_to_days,
                 person_to_week));
         } else {
-            List<Person> additional_people = Application.allPeople();
+            List<Person> additional_people = Application.attendancePeople();
             additional_people.removeAll(all_people);
 
             Collections.sort(additional_people, Person.SORT_DISPLAY_NAME);

--- a/app/models/Case.java
+++ b/app/models/Case.java
@@ -178,7 +178,7 @@ public class Case extends Model implements Comparable<Case> {
         }
 
         // Add first and display names of all people in JC db
-        for(Person p : Application.allPeople()) {
+        for(Person p : Application.jcPeople()) {
             names.add(p.first_name.trim().toLowerCase());
             names.add(p.getDisplayName().trim().toLowerCase());
         }


### PR DESCRIPTION
This fixes two bugs with tags:
1. The account autocompletes in the create transaction page were including all people, even ones who did not have tags marked as show_in_account_balances
2. The attendance system was using show_in_jc rather than show_in_attendance