### PR TITLE
Use correct date when fetching roster data

### DIFF
--- a/app/assets/checkin/app.js
+++ b/app/assets/checkin/app.js
@@ -217,7 +217,8 @@ async function poll() {
 
 async function downloadData() {
 	console.log('downloading application data');
-	let response = await fetch('/attendance/checkin/data');
+	let time = new Date().toLocaleString('en-US');
+	let response = await fetch('/attendance/checkin/data?time=' + time);
 	// 'redirected' means we are not logged in to the server
 	if (response.redirected) {
 		let success = await logIn();
@@ -252,7 +253,8 @@ async function downloadRoster() {
 	// nothing. This allows the user to see data that is guaranteed to be current, or allows
 	// them to see that the app is offline.
 	try {
-		let response = await fetch('/attendance/checkin/data');
+		let time = new Date().toLocaleString('en-US');
+		let response = await fetch('/attendance/checkin/data?time=' + time);
 		// 'redirected' means we are not logged in to the server
 		if (response.redirected) {
 			return -1;

--- a/app/controllers/Checkin.java
+++ b/app/controllers/Checkin.java
@@ -19,11 +19,12 @@ import play.mvc.*;
 @Secured.Auth(UserRole.ROLE_CHECKIN_APP)
 public class Checkin extends Controller {
 
-    public Result checkinData() {
+    public Result checkinData(String time) throws ParseException {
+        Date date = new SimpleDateFormat("M/d/yyyy, h:mm:ss a").parse(time);
         List<CheckinPerson> people = Application.attendancePeople().stream()
             .sorted(Comparator.comparing(Person::getDisplayName))
             .filter(p -> p.pin != null && !p.pin.isEmpty())
-            .map(p -> new CheckinPerson(p, findCurrentDay(new Date(), p.person_id)))
+            .map(p -> new CheckinPerson(p, findCurrentDay(date, p.person_id)))
             .collect(Collectors.toList());
 
         return ok(Json.stringify(Json.toJson(people)));

--- a/conf/routes
+++ b/conf/routes
@@ -105,7 +105,7 @@ GET     /attendance/jsonPeople               controllers.Attendance.jsonPeople(t
 GET     /attendance/viewWeek	  controllers.Attendance.viewWeek(date : String ?= "")
 GET     /attendance/editWeek      controllers.Attendance.editWeek(date : String ?= "")
 GET  	/attendance/checkin				controllers.Public.checkin()
-GET     /attendance/checkin/data 		controllers.Checkin.checkinData()
+GET     /attendance/checkin/data 		controllers.Checkin.checkinData(time: String)
 POST    /attendance/checkin/message 	controllers.Checkin.checkinMessage(time_string: String, person_id: Integer, is_arriving: Boolean)
 GET     /attendance/pins         controllers.Attendance.assignPINs()
 GET     /attendance/savepins       controllers.Attendance.savePINs()


### PR DESCRIPTION
There was a bug which was causing the Roster to display tomorrow's data when accessed after 5pm Pacific. This is the same time zone bug that I fixed earlier with data uploading.