### PR TITLE
Fix time zone bug in checkin app's editable roster

### DIFF
--- a/app/assets/checkin/app.js
+++ b/app/assets/checkin/app.js
@@ -484,7 +484,8 @@ async function createAdminMessage(person, in_time, out_time, absence_code) {
 		person_id: person.person_id,
 		in_time: in_time,
 		out_time: out_time,
-		absence_code: absence_code
+		absence_code: absence_code,
+		time_string: new Date().toLocaleString('en-US')
 	}
 	await saveAdminMessage(message);
 	trySendMessages();
@@ -519,7 +520,7 @@ function trySendMessages() {
 	    		query_string = `?time_string=${message.time_string}&person_id=${message.person_id}&is_arriving=${message.is_arriving}`;
 	    		url = '/attendance/checkin/message' + query_string;
 	    	} else {
-	    		query_string = `?person_id=${message.person_id}&in_time=${message.in_time}&out_time=${message.out_time}&absence_code=${message.absence_code}`;
+	    		query_string = `?person_id=${message.person_id}&in_time=${message.in_time}&out_time=${message.out_time}&absence_code=${message.absence_code}&time_string=${message.time_string}`;
 	    		url = '/attendance/checkin/adminmessage' + query_string;
 	    	}
 	    	fetch(url, { method: 'POST' }).then(response => {

--- a/app/assets/checkin/service-worker.js
+++ b/app/assets/checkin/service-worker.js
@@ -1,7 +1,7 @@
 // https://codelabs.developers.google.com/codelabs/your-first-pwapp/#4
 
 // update cache names any time any of the cached files change
-const CACHE_NAME = 'static-cache-v230';
+const CACHE_NAME = 'static-cache-v236';
 
 const FILES_TO_CACHE = [
 	'/assets/checkin/app.html',

--- a/app/controllers/Checkin.java
+++ b/app/controllers/Checkin.java
@@ -64,8 +64,14 @@ public class Checkin extends Controller {
         return ok();
     }
 
-    public Result adminMessage(int person_id, String in_time, String out_time, String absence_code) throws Exception {
-        AttendanceDay attendance_day = AttendanceDay.findCurrentDay(new Date(), person_id);
+    public Result adminMessage(int person_id, String in_time, String out_time, String absence_code, String time_string) throws Exception {
+        Date date = new Date();
+        // We use time_string to determine which day it is according to the client. This could be different
+        // from the current day according to the server, depending on the client's time zone.
+        if (!time_string.isEmpty()) {
+            date = new SimpleDateFormat("M/d/yyyy, h:mm:ss a").parse(time_string);
+        }
+        AttendanceDay attendance_day = AttendanceDay.findCurrentDay(date, person_id);
         if (attendance_day != null) {
             attendance_day.edit(absence_code, in_time, out_time);
         }

--- a/conf/routes
+++ b/conf/routes
@@ -107,7 +107,7 @@ GET     /attendance/editWeek      controllers.Attendance.editWeek(date : String 
 GET  	/attendance/checkin				controllers.Public.checkin()
 GET     /attendance/checkin/data 		controllers.Checkin.checkinData(time: String)
 POST    /attendance/checkin/message 	controllers.Checkin.checkinMessage(time_string: String, person_id: Integer, is_arriving: Boolean)
-POST    /attendance/checkin/adminmessage 	controllers.Checkin.adminMessage(person_id: Integer, in_time: String, out_time: String, absence_code: String)
+POST    /attendance/checkin/adminmessage 	controllers.Checkin.adminMessage(person_id: Integer, in_time: String, out_time: String, absence_code: String, time_string: String ?= "")
 GET     /attendance/pins         controllers.Attendance.assignPINs()
 GET     /attendance/savepins       controllers.Attendance.savePINs()
 GET     /attendance/offCampusTime         controllers.Attendance.offCampusTime()


### PR DESCRIPTION
This is the same time zone bug as before, this time affecting the admin messages from the editable roster. The editable roster was sending over the correct time (because the admin enters the time manually), but sometimes it would be for the wrong day.