### PR TITLE
Add "not counted" absence code type

### DIFF
--- a/app/assets/stylesheets/main.less
+++ b/app/assets/stylesheets/main.less
@@ -880,6 +880,10 @@ border-radius: 6px 0 6px 6px;
   padding-left: 10px;
 }
 
+input[type="checkbox"].absence-checkbox {
+  margin-top: 10px;
+}
+
 /*
  * End copy from stackoverflow
  **************************************************************************/

--- a/app/models/AttendanceCode.java
+++ b/app/models/AttendanceCode.java
@@ -29,6 +29,7 @@ public class AttendanceCode extends Model {
     public String color="#000000";
 
     public boolean counts_toward_attendance = false;
+    public boolean not_counted = false;
 
     public static Finder<Integer, AttendanceCode> find = new Finder<Integer, AttendanceCode>(
         AttendanceCode.class
@@ -63,6 +64,7 @@ public class AttendanceCode extends Model {
         code = form.field("code").value();
         color = form.field("color").value();
         counts_toward_attendance = Utils.getBooleanFromFormValue(form.field("counts_toward_attendance").value());
+        not_counted = Utils.getBooleanFromFormValue(form.field("not_counted").value());
 
         this.update();
     }

--- a/app/models/AttendanceStats.java
+++ b/app/models/AttendanceStats.java
@@ -20,7 +20,7 @@ public class AttendanceStats {
             return;
         }
         // "no school" days do not count as absences
-        if (!code.code.equals("_NS_")) {
+        if (!code.code.equals("_NS_") && !code.not_counted) {
             if (code.counts_toward_attendance) {
                 approved_absences++;
             } else {

--- a/app/views/attendance_code_form.scala.html
+++ b/app/views/attendance_code_form.scala.html
@@ -40,7 +40,8 @@ $(function() {
 @inputText(code_form("color"), '_label -> "Color", 'class -> "colorpicker")
 
 @if( OrgConfig.get().org.attendance_show_percent ) {
-	@checkbox(code_form("counts_toward_attendance"), '_label -> "Counts toward attendance rate")
+	@checkbox(code_form("counts_toward_attendance"), '_label -> "Counts toward attendance rate", 'class -> "absence-checkbox")
+	@checkbox(code_form("not_counted"), '_label -> "Neither counts toward nor against attendance rate", 'class -> "absence-checkbox")
 }
 
 @if(is_editing) {

--- a/conf/evolutions/default/86.sql
+++ b/conf/evolutions/default/86.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+ALTER TABLE attendance_code ADD COLUMN not_counted boolean NOT NULL DEFAULT false;
+
+# --- !Downs
+ALTER TABLE attendance_code DROP COLUMN not_counted;


### PR DESCRIPTION
I want to create an absence code that neither counts toward nor against attendance rate (the same way `_NS_` does), so I'm adding a checkbox to the absence code editor.