### PR TITLE
Add "minutes exempted" field to Attendance Day

### DIFF
--- a/app/controllers/Attendance.java
+++ b/app/controllers/Attendance.java
@@ -758,11 +758,13 @@ public class Attendance extends Controller {
                 Date day = df.parse(data.get("day-" + i));
                 Time departure_time = AttendanceDay.parseTime(data.get("departuretime-" + i));
                 Time return_time = AttendanceDay.parseTime(data.get("returntime-" + i));
+                Integer minutes_exempted = AttendanceDay.parseInt(data.get("minutesexempted-" + i));
 
                 if (person_id != null && day != null && departure_time != null && return_time != null) {
                     AttendanceDay attendance_day = AttendanceDay.findCurrentDay(day, person_id);
                     attendance_day.off_campus_departure_time = departure_time;
                     attendance_day.off_campus_return_time = return_time;
+                    attendance_day.off_campus_minutes_exempted = minutes_exempted;
                     attendance_day.update();
                 }
             } catch (NumberFormatException e) {

--- a/app/models/AttendanceDay.java
+++ b/app/models/AttendanceDay.java
@@ -35,6 +35,7 @@ public class AttendanceDay extends Model {
 
     public Time off_campus_departure_time;
     public Time off_campus_return_time;
+    public Integer off_campus_minutes_exempted;
 
     public static Finder<Integer, AttendanceDay> find = new Finder<Integer, AttendanceDay>(
         AttendanceDay.class
@@ -75,6 +76,13 @@ public class AttendanceDay extends Model {
 		return null;
     }
 
+    public static Integer parseInt(String str) {
+        if (str == null || str.equals("")) {
+            return null;
+        }
+        return Integer.parseInt(str);
+    }
+
     public void edit(String code, String start_time, String end_time) throws Exception {
         if (code.equals("")) {
             this.code = null;
@@ -93,6 +101,12 @@ public class AttendanceDay extends Model {
         long off_campus_time = 0;
         if (off_campus_return_time != null && off_campus_departure_time != null) {
             off_campus_time = off_campus_return_time.getTime() - off_campus_departure_time.getTime();
+            if (off_campus_minutes_exempted != null) {
+                off_campus_time -= off_campus_minutes_exempted * 60 * 1000;
+                if (off_campus_time < 0) {
+                    off_campus_time = 0;
+                }
+            }
         }
         return (end_time.getTime() - start_time.getTime() - off_campus_time) / (1000.0 * 60 * 60);
     }

--- a/app/views/attendance_add_off_campus.scala.html
+++ b/app/views/attendance_add_off_campus.scala.html
@@ -14,6 +14,7 @@
 		<th>Person</th>
 		<th>Departure Time</th>
 		<th>Return Time</th>
+		<th>Minutes Exempted</th>
 	</tr>
 	@for( i <- 0 to 9 ) {
 		<tr>
@@ -28,6 +29,7 @@
 			</td>
 			<td><input type="text" class="js-time attendance-off-campus-time" name="departuretime-@i"></td>
 			<td><input type="text" class="js-time attendance-off-campus-time" name="returntime-@i"></td>
+			<td><input type="number" min="0" max="9999" class="attendance-off-campus-time" name="minutesexempted-@i"></td>
 		</tr>
 	}
 </table>

--- a/app/views/attendance_off_campus.scala.html
+++ b/app/views/attendance_off_campus.scala.html
@@ -17,6 +17,7 @@
 		<th>Person</th>
 		<th>Departure Time</th>
 		<th>Return Time</th>
+		<th>Minutes Exempted</th>
 	</tr>
 	@for( d <- days ) {
 		<tr>
@@ -25,6 +26,7 @@
 			<td>@d.person.getDisplayName()</td>
 			<td>@Attendance.formatTime(d.off_campus_departure_time)</td>
 			<td>@Attendance.formatTime(d.off_campus_return_time)</td>
+			<td>@d.off_campus_minutes_exempted</td>
 		</tr>
 	}
 </table>

--- a/app/views/attendance_person.scala.html
+++ b/app/views/attendance_person.scala.html
@@ -85,6 +85,7 @@
 	@if( has_off_campus_time ) {
 		<th width=75>Off Campus Start Time</th>
 		<th width=75>Off Campus End Time</th>
+		<th width=75>Minutes Exempted</th>
 	}
 	<th width=100>Absence code</th>
 	<th width=100>Extra hours (weekly)</th>
@@ -125,6 +126,7 @@
 	@if( has_off_campus_time ) {
 		<td>@Attendance.formatTime(d.off_campus_departure_time)</td>
 		<td>@Attendance.formatTime(d.off_campus_return_time)</td>
+		<td>@d.off_campus_minutes_exempted</td>
 	}
 	@if(d.code != null) {
 		@if(codes_map.contains(d.code)) {

--- a/conf/evolutions/default/89.sql
+++ b/conf/evolutions/default/89.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+
+ALTER TABLE attendance_day ADD COLUMN off_campus_minutes_exempted integer;
+
+# --- !Downs
+
+ALTER TABLE attendance_day DROP COLUMN off_campus_minutes_exempted;


### PR DESCRIPTION
Adding "minutes exempted" to the Off Campus Time feature. This adds an extra column when editing/viewing off campus time. 

Normally off campus time is not counted towards the student's attendance for the day. When minutes exempted is set, that number of minutes of the off campus time WILL be counted towards the student's attendance for the day. 