### PR TITLE
Add ability to filter by date range in attendance summary

### DIFF
--- a/app/controllers/Attendance.java
+++ b/app/controllers/Attendance.java
@@ -37,9 +37,11 @@ public class Attendance extends Controller {
         return code_form;
     }
 
-    String renderIndexContent(Date start_date) {
-        Date end_date = new Date(start_date.getTime());
-        end_date.setYear(end_date.getYear() + 1);
+    String renderIndexContent(Date start_date, Date end_date, Boolean is_custom_date) {
+        if (end_date == null) {
+            end_date = new Date(start_date.getTime());
+            end_date.setYear(end_date.getYear() + 1);
+        }
         Map<Person, AttendanceStats> person_to_stats = new HashMap<>();
         Map<String, AttendanceCode> codes_map = getCodesMap(false);
 
@@ -96,11 +98,11 @@ public class Attendance extends Controller {
 
         return views.html.attendance_index.render(
                 all_people, person_to_stats, all_codes, codes_map,
-                Application.attendancePeople(), start_date, prev_date, next_date).toString();
+                Application.attendancePeople(), start_date, end_date, is_custom_date, prev_date, next_date).toString();
     }
 
-    public Result index(String start_date) {
-        if (start_date.equals("")) {
+    public Result index(String start_date_str, String end_date_str, Boolean is_custom_date) {
+        if (start_date_str.equals("")) {
             return ok(views.html.cached_page.render(
                     new CachedPage(CachedPage.ATTENDANCE_INDEX,
                             "Attendance",
@@ -108,7 +110,7 @@ public class Attendance extends Controller {
                             "attendance_home") {
                         @Override
                         String render() {
-                            return renderIndexContent(Application.getStartOfYear());
+                            return renderIndexContent(Application.getStartOfYear(), null, false);
                         }
                     }));
         } else {
@@ -119,7 +121,12 @@ public class Attendance extends Controller {
                             "attendance_home") {
                         @Override
                         public String getPage() {
-                            return renderIndexContent(Utils.parseDateOrNow(start_date).getTime());
+                            Date start_date = Utils.parseDateOrNow(start_date_str).getTime();
+                            Date end_date = null;
+                            if (!end_date_str.equals("")) {
+                                end_date = Utils.parseDateOrNow(end_date_str).getTime();
+                            }
+                            return renderIndexContent(start_date, end_date, is_custom_date);
                         }
 
                         @Override

--- a/app/views/attendance_index.scala.html
+++ b/app/views/attendance_index.scala.html
@@ -1,6 +1,6 @@
 @(people : List[Person], person_to_stats : Map[Person, AttendanceStats],
   codes : List[String], codes_map : Map[String, AttendanceCode], current_people: List[Person],
-  start_date: Date, prev_date: Date, next_date: Date)
+  start_date: Date, end_date: Date, is_custom_date: Boolean, prev_date: Date, next_date: Date)
 
 @import helper._
 
@@ -41,22 +41,35 @@ $(function() {
 </script>
 
 <h3>Attendance Summary</h3>
-<h4>For one year starting @Application.yymmddDate(start_date)
-    <a href="@routes.Attendance.download(Application.forDateInput(start_date))" class="download-link">
-        <span class="glyphicon glyphicon-download-alt"></span>Download as spreadsheet
-    </a>
-</h4>
-<p>
-    <a href="@routes.Attendance.index(Application.forDateInput(prev_date))">⇐ Previous Year</a>
-    @if( next_date != null ) {
-        <a href="@routes.Attendance.index(Application.forDateInput(next_date))"
-           style="margin-left: 100px;">Next Year ⇒</a>
-    }
-</p>
-@if( next_date == null ) {
+@if( !is_custom_date ) {
+	<h4>For one year starting @Application.yymmddDate(start_date)
+	    <a href="@routes.Attendance.download(Application.forDateInput(start_date))" class="download-link">
+	        <span class="glyphicon glyphicon-download-alt"></span>Download as spreadsheet
+	    </a>
+	</h4>
+	<p>
+	    <a href="@routes.Attendance.index(Application.forDateInput(prev_date))">⇐ Previous Year</a>
+	    @if( next_date != null ) {
+	        <a href="@routes.Attendance.index(Application.forDateInput(next_date))"
+	           style="margin-left: 100px;">Next Year ⇒</a>
+	    }
+	</p>
+}
+<form method="GET">
+	<p>Showing
+		<input type="date" name="start_date" value="@Application.forDateInput(start_date)"> to
+		<input type="date" name="end_date" value="@Application.forDateInput(end_date)">
+		<input type="hidden" name="is_custom_date" value="true">
+		<input class="btn btn-xs btn-primary" type="submit">
+	</p>
+</form>
+@if( next_date == null || is_custom_date ) {
 	<div id="attendance-student-picker">
 		<label><input type="radio" name="type" value="current"> Show only current students and staff</label><br>
-		<label><input type="radio" name="type" value="all" checked> Show all people who have attended this school year</label>
+		<label>
+			<input type="radio" name="type" value="all" checked> Show all people who have attended
+			@if( is_custom_date ) { during the date range } else { this school year }
+		</label>
 	</div>
 }
 <p style="margin-bottom: 30px;">Click on a column title to sort by that column. Click again to sort in the opposite direction.

--- a/conf/routes
+++ b/conf/routes
@@ -100,7 +100,7 @@ GET     /people/:id               controllers.CRM.person(id: Integer)
 POST    /people                   controllers.CRM.makeNewPerson()
 POST    /people/:id/delete        controllers.CRM.deletePerson(id: Integer)
 
-GET     /attendance		  controllers.Attendance.index(start_of_year ?= "")
+GET     /attendance		  controllers.Attendance.index(start_date ?= "", end_date: String ?= "", is_custom_date: Boolean ?= false)
 GET     /attendance/jsonPeople               controllers.Attendance.jsonPeople(term ?= "")
 GET     /attendance/viewWeek	  controllers.Attendance.viewWeek(date : String ?= "")
 GET     /attendance/editWeek      controllers.Attendance.editWeek(date : String ?= "")


### PR DESCRIPTION
I want to be able to see attendance data for all students for a given date range (rather than just by school year). To accomplish this, I've added a date range input near the top of the Attendance index page. For people who don't care about this feature, it will just display 8/1/2021 to 8/1/2022 (or whatever year). If you edit the dates and click Submit, it will take you to a slightly modified index page that excludes some of the header elements (the "previous year" button, etc.).

Since this affects how all users see the Attendance index page, I tried to implement it such that it doesn't get in the way. Let me know if you think there is a better way to structure the UI for this feature.