### PR TITLE
Add attendance rate to Check-in hello screen

### DIFF
--- a/app/assets/checkin/app-compiled.js
+++ b/app/assets/checkin/app-compiled.js
@@ -1584,7 +1584,11 @@ function _submitCode() {
 function setAuthorized(person, is_arriving) {
   createMessage(person, is_arriving);
   container.innerHTML = authorized_template.innerHTML;
-  document.querySelector('.authorized-text').innerHTML = getAuthorizedText(person, is_arriving); // We will automatically return to the home screen after a period of time if the OK
+  document.querySelector('.authorized-text').innerHTML = getAuthorizedText(person, is_arriving);
+  if (is_arriving && person.attendance_rate) {
+    document.querySelector('.authorized-data').innerHTML = getAuthorizedData(person);
+  }
+  // We will automatically return to the home screen after a period of time if the OK
   // button is not pressed.
 
   var hasReset = false;
@@ -1613,6 +1617,10 @@ function getAuthorizedText(person, is_arriving) {
 
   authorized_text += person.name;
   return authorized_text;
+}
+
+function getAuthorizedData(person) {
+  return `Your current attendance<br>rate is <strong>${person.attendance_rate}</strong>`;
 }
 
 function setUnauthorized() {

--- a/app/assets/checkin/app.html
+++ b/app/assets/checkin/app.html
@@ -111,6 +111,7 @@
 			<div class="authorized-check">&#10004;</div>
 			<div class="authorized-text"></div>
 			<div><button class="ok-button">OK</button></div>
+			<div class="authorized-data"></div>
 		</div>
 	</script>
 

--- a/app/assets/checkin/app.js
+++ b/app/assets/checkin/app.js
@@ -421,6 +421,9 @@ function setAuthorized(person, is_arriving) {
 	createMessage(person, is_arriving);
 	container.innerHTML = authorized_template.innerHTML;
 	document.querySelector('.authorized-text').innerHTML = getAuthorizedText(person, is_arriving);
+	if (is_arriving && person.attendance_rate) {
+		document.querySelector('.authorized-data').innerHTML = getAuthorizedData(person);
+	}
 	// We will automatically return to the home screen after a period of time if the OK
 	// button is not pressed.
 	var hasReset = false;
@@ -446,6 +449,10 @@ function getAuthorizedText(person, is_arriving) {
 	}
 	authorized_text += person.name;
 	return authorized_text;
+}
+
+function getAuthorizedData(person) {
+	return `Your current attendance<br>rate is <strong>${person.attendance_rate}</strong>`;
 }
 
 function setUnauthorized() {

--- a/app/assets/checkin/service-worker.js
+++ b/app/assets/checkin/service-worker.js
@@ -1,7 +1,7 @@
 // https://codelabs.developers.google.com/codelabs/your-first-pwapp/#4
 
 // update cache names any time any of the cached files change
-const CACHE_NAME = 'static-cache-v241';
+const CACHE_NAME = 'static-cache-v255';
 
 const FILES_TO_CACHE = [
 	'/assets/checkin/app.html',

--- a/app/assets/checkin/style.css
+++ b/app/assets/checkin/style.css
@@ -134,6 +134,11 @@ button {
 	color: #f00;
 }
 
+.authorized-data {
+	margin-top: 70px;
+	color:  #666;
+}
+
 .roster-failed-symbol {
 	color: #ff9b00;
 }

--- a/app/assets/stylesheets/main.less
+++ b/app/assets/stylesheets/main.less
@@ -876,7 +876,7 @@ border-radius: 6px 0 6px 6px;
 
 .depends-on-partial-days {
   border-left: 3px solid #ccc;
-  margin-left: 30px;
+  margin-left: 10px;
   padding-left: 10px;
 }
 

--- a/app/models/CheckinPerson.java
+++ b/app/models/CheckinPerson.java
@@ -1,6 +1,7 @@
 package models;
 
 import java.text.SimpleDateFormat;
+import controllers.Attendance;
 
 public class CheckinPerson {
     
@@ -10,11 +11,19 @@ public class CheckinPerson {
     public String current_day_code;
     public String current_day_start_time;
     public String current_day_end_time;
+    public String attendance_rate;
 
-    public CheckinPerson(Person person, AttendanceDay current_day) {
+    public CheckinPerson(Person person, AttendanceDay current_day, AttendanceStats stats) {
         person_id = person.person_id;
         pin = person.pin;
         name = person.getDisplayName();
+
+        if (stats != null && OrgConfig.get().org.attendance_show_percent) {
+            double rate = stats.attendanceRate();
+            if (!Double.isNaN(rate)) {
+                attendance_rate = Attendance.formatAsPercent(rate);
+            }
+        }
 
         if (current_day != null) {
             SimpleDateFormat format = new SimpleDateFormat("h:mm aa");

--- a/app/models/Organization.java
+++ b/app/models/Organization.java
@@ -58,6 +58,7 @@ public class Organization extends Model {
     public Time attendance_day_latest_start_time;
     public Integer attendance_day_min_hours;
     public BigDecimal attendance_partial_day_value;
+    public Integer attendance_rate_standard_time_frame;
     public String attendance_admin_pin;
 
     @OneToMany(mappedBy="organization")
@@ -216,6 +217,11 @@ public class Organization extends Model {
                 this.attendance_partial_day_value = null;
             } else {
                 this.attendance_partial_day_value = new BigDecimal(values.get("attendance_partial_day_value")[0]);
+            }
+            if (!values.containsKey("attendance_rate_standard_time_frame") || values.get("attendance_rate_standard_time_frame")[0].isEmpty()) {
+                this.attendance_rate_standard_time_frame = null;
+            } else {
+                this.attendance_rate_standard_time_frame = Integer.parseInt(values.get("attendance_rate_standard_time_frame")[0]);
             }
             if (values.containsKey("attendance_day_latest_start_time")) {
                 this.attendance_day_latest_start_time = AttendanceDay.parseTime(values.get("attendance_day_latest_start_time")[0]);

--- a/app/views/attendance_index.scala.html
+++ b/app/views/attendance_index.scala.html
@@ -1,6 +1,7 @@
 @(people : List[Person], person_to_stats : Map[Person, AttendanceStats],
   codes : List[String], codes_map : Map[String, AttendanceCode], current_people: List[Person],
-  start_date: Date, end_date: Date, is_custom_date: Boolean, prev_date: Date, next_date: Date)
+  start_date: Date, end_date: Date, is_custom_date: Boolean, prev_date: Date, next_date: Date,
+  standard_time_frame_start: Date, today: Date, standard_time_frame_days: Integer, is_standard_time_frame: Boolean)
 
 @import helper._
 
@@ -54,6 +55,11 @@ $(function() {
 	           style="margin-left: 100px;">Next Year ⇒</a>
 	    }
 	</p>
+}
+@if(standard_time_frame_days != null && !is_standard_time_frame) {
+	<p><a href="@routes.Attendance.index(Application.forDateInput(standard_time_frame_start), Application.forDateInput(today), true)">
+	 	Show last @standard_time_frame_days school days
+	</a></p>
 }
 <form method="GET">
 	<p>Showing

--- a/app/views/view_settings.scala.html
+++ b/app/views/view_settings.scala.html
@@ -138,44 +138,50 @@ the other way around.</p>
     &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
         title="This allows you to see a person's attendance rate as a percentage of days present vs. total school days."></span>
 
-    <br/>
+    <div>
+        Use the last
+        <input type="number" min="0" max="999" name="attendance_rate_standard_time_frame" value="@org.attendance_rate_standard_time_frame">
+        school days as the standard for calculating attendance rate
+        &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
+                    title="If a value is given here, the Check-in app will use this time frame to calculate attendance rate instead of using the whole school year. (The Check-in app shows a student's attendance rate when they check in.) A button will also be added to the Attendance By Year page to be able to easily view this time frame for all students."></span>
+    </div>
     <label>
         <input type="checkbox" name="attendance_enable_partial_days" id="attendance-enable-partial-days"
                class="has-dependents" data-dependent-class="depends-on-partial-days"
                @if(org.attendance_enable_partial_days){ checked }>
         Count partial days separately from full days
     </label>
+    <div class="depends-on-partial-days"><table><tbody>
+        <tr>
+            <td>Latest arrival time allowed for a full day</td>
+            <td>
+                <input type="text" size="7" name="attendance_day_latest_start_time" value="@org.formatAttendanceLatestStartTime()"
+                       @if(!org.show_attendance || !org.attendance_enable_partial_days){ disabled }>
+                &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
+                    title="If a person arrives later than this time (e.g. 11:00), the day counts as a partial day regardless of how many hours the person was at school."></span>
+            </td>
+        </tr>
+        <tr>
+            <td>Minimum hours for a full day</td>
+            <td>
+                <input type="number" min="0" max="9" name="attendance_day_min_hours" value="@org.attendance_day_min_hours"
+                       @if(!org.show_attendance || !org.attendance_enable_partial_days){ disabled }>
+                &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
+                    title="If a person is present for fewer than this number of hours (e.g. 5) in a day, it counts as a partial day."></span>
+            </td>
+        </tr>
+        <tr>
+            <td>Value of a partial day for attendance rate</td>
+            <td>
+                <input type="number" min="0" max="1" step="0.05" name="attendance_partial_day_value"
+                       value="@org.attendance_partial_day_value"
+                       @if(!org.show_attendance || !org.attendance_enable_partial_days){ disabled }>
+                &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
+                    title="If the Attendance Rate column is enabled, you can decide how much value a partial day has in the percentage calculation. For example, if the value is 0.5, a partial day counts as half of a full day."></span>
+            </td>
+        </tr>
+    </tbody></table></div>
 </div>
-<div class="depends-on-partial-days"><table><tbody>
-    <tr>
-        <td>Latest arrival time allowed for a full day</td>
-        <td>
-            <input type="text" size="7" name="attendance_day_latest_start_time" value="@org.formatAttendanceLatestStartTime()"
-                   @if(!org.show_attendance || !org.attendance_enable_partial_days){ disabled }>
-            &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
-                title="If a person arrives later than this time (e.g. 11:00), the day counts as a partial day regardless of how many hours the person was at school."></span>
-        </td>
-    </tr>
-    <tr>
-        <td>Minimum hours for a full day</td>
-        <td>
-            <input type="number" min="0" max="9" name="attendance_day_min_hours" value="@org.attendance_day_min_hours"
-                   @if(!org.show_attendance || !org.attendance_enable_partial_days){ disabled }>
-            &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
-                title="If a person is present for fewer than this number of hours (e.g. 5) in a day, it counts as a partial day."></span>
-        </td>
-    </tr>
-    <tr>
-        <td>Value of a partial day for attendance rate</td>
-        <td>
-            <input type="number" min="0" max="1" step="0.05" name="attendance_partial_day_value"
-                   value="@org.attendance_partial_day_value"
-                   @if(!org.show_attendance || !org.attendance_enable_partial_days){ disabled }>
-            &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
-                title="If the Attendance Rate column is enabled, you can decide how much value a partial day has in the percentage calculation. For example, if the value is 0.5, a partial day counts as half of a full day."></span>
-        </td>
-    </tr>
-</tbody></table></div>
 <h4>Custodia</h4>
 <p>
     <label>

--- a/conf/evolutions/default/90.sql
+++ b/conf/evolutions/default/90.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+
+ALTER TABLE organization ADD COLUMN attendance_rate_standard_time_frame integer;
+
+# --- !Downs
+
+ALTER TABLE organization DROP COLUMN attendance_rate_standard_time_frame;


### PR DESCRIPTION
I wanted to show a person's current attendance rate when they check in using the Check-in app. To do this, I needed to standardize the time frame over which the attendance rate is calculated (i.e. only look at the last 60 school days). This project includes:
1. Creating a setting for the number of school days to look in the past
2. Creating shared methods for computing attendance rate that can be used by both the Check-in app and the main Attendance tool
3. Displaying the attendance rate in the Check-in app
4. Adding a button to the Attendance By Year page to easily view the standard time frame for all students