### PR TITLE
Update attendance report to group students and calculate late fees

### DIFF
--- a/app/assets/stylesheets/main.less
+++ b/app/assets/stylesheets/main.less
@@ -893,14 +893,20 @@ input[type="checkbox"].absence-checkbox {
 .attendance-report-settings {
     border-collapse: separate;
     border-spacing: 7px;
-
     th {
         font-weight: normal;
     }
-
     select {
         padding: 3px;
     }
+}
+
+.attendance-report-late-departures-table {
+    max-width: 600px;
+}
+
+.attendance-report-late-departure-group {
+    background: #eee;
 }
 
 /*

--- a/app/models/AttendanceDay.java
+++ b/app/models/AttendanceDay.java
@@ -37,6 +37,9 @@ public class AttendanceDay extends Model {
     public Time off_campus_return_time;
     public Integer off_campus_minutes_exempted;
 
+    @Transient
+    public Integer late_fee;
+
     public static Finder<Integer, AttendanceDay> find = new Finder<Integer, AttendanceDay>(
         AttendanceDay.class
     );

--- a/app/models/LateDepartureGroup.java
+++ b/app/models/LateDepartureGroup.java
@@ -1,0 +1,44 @@
+package models;
+
+import java.text.*;
+import java.util.*;
+import java.math.*;
+import javax.persistence.*;
+import com.fasterxml.jackson.annotation.*;
+import play.data.*;
+import com.avaje.ebean.*;
+import java.sql.Time;
+
+public class LateDepartureGroup {
+    
+    public String name;
+    public List<AttendanceDay> events;
+
+    public Integer late_fee;
+    public Integer late_fee_interval;
+    public Time latest_departure_time;
+
+    public LateDepartureGroup(String person_name) {
+        name = person_name;
+        events = new ArrayList<AttendanceDay>();
+
+        Organization org = OrgConfig.get().org;
+        late_fee = org.attendance_report_late_fee;
+        late_fee_interval = org.attendance_report_late_fee_interval;
+        latest_departure_time = org.attendance_report_latest_departure_time;
+    }
+
+    public Integer getTotalOwed() {
+        if (late_fee == null || late_fee == 0 || late_fee_interval == null || late_fee_interval == 0) {
+            return null;
+        }
+        int total_owed = 0;
+        for (AttendanceDay event : events) {
+            int minutes_late = (int)(event.end_time.getTime() / (60 * 1000)) - (int)(latest_departure_time.getTime() / (60 * 1000));
+            int intervals = (minutes_late + late_fee_interval - 1) / late_fee_interval;
+            event.late_fee = intervals * late_fee;
+            total_owed += event.late_fee;
+        }
+        return total_owed;
+    }
+}

--- a/app/models/Organization.java
+++ b/app/models/Organization.java
@@ -53,6 +53,8 @@ public class Organization extends Model {
     public Boolean attendance_enable_off_campus;
     public Boolean attendance_show_reports;
     public Time attendance_report_latest_departure_time;
+    public Integer attendance_report_late_fee;
+    public Integer attendance_report_late_fee_interval;
     public Boolean attendance_show_percent;
     public Boolean attendance_enable_partial_days;
     public Time attendance_day_latest_start_time;
@@ -232,6 +234,16 @@ public class Organization extends Model {
                 this.attendance_report_latest_departure_time = AttendanceDay.parseTime(values.get("attendance_report_latest_departure_time")[0]);
             } else {
                 this.attendance_report_latest_departure_time = null;
+            }
+            if (!values.containsKey("attendance_report_late_fee") || values.get("attendance_report_late_fee")[0].isEmpty()) {
+                this.attendance_report_late_fee = null;
+            } else {
+                this.attendance_report_late_fee = Integer.parseInt(values.get("attendance_report_late_fee")[0]);
+            }
+            if (!values.containsKey("attendance_report_late_fee_interval") || values.get("attendance_report_late_fee_interval")[0].isEmpty()) {
+                this.attendance_report_late_fee_interval = null;
+            } else {
+                this.attendance_report_late_fee_interval = Integer.parseInt(values.get("attendance_report_late_fee_interval")[0]);
             }
         }
         if (values.containsKey("accounting_settings")) {

--- a/app/views/attendance_reports.scala.html
+++ b/app/views/attendance_reports.scala.html
@@ -42,19 +42,32 @@
 		</table>
 	}
 
-	@if(model.events != null) {
-		<table class="table sortable">
+	@if(model.late_departures != null) {
+		<table class="table attendance-report-late-departures-table">
 			<tr>
 				<th>Person</th>
+				<th>Total Owed</th>
 				<th>Date</th>
 				<th>Departure Time</th>
+				<th>Fee</th>
 			</tr>
-			@for(event <- model.events) {
-				<tr>
-					<td>@event.person.getDisplayName()</td>
-					<td>@event.getFormattedDate()</td>
-					<td>@Attendance.formatTime(event.end_time)</td>
+			@for(group <- model.late_departures) {
+				<tr class="attendance-report-late-departure-group">
+					<td>@group.name</td>
+					<td>$@group.getTotalOwed()</td>
+					<td></td>
+					<td></td>
+					<td></td>
 				</tr>
+				@for(event <- group.events) {
+					<tr>
+						<td></td>
+						<td></td>
+						<td>@event.getFormattedDate()</td>
+						<td>@Attendance.formatTime(event.end_time)</td>
+						<td>$@event.late_fee</td>
+					</tr>
+				}
 			}
 		</table>
 	}

--- a/app/views/view_settings.scala.html
+++ b/app/views/view_settings.scala.html
@@ -119,16 +119,20 @@ the other way around.</p>
         Show the "Reports" tab
     </label>
 
-    <div class="depends-on-attendance-reports"><table><tbody>
-        <tr>
-            <td>Latest allowed departure time &nbsp;</td>
-            <td>
-                <input type="text" size="7" name="attendance_report_latest_departure_time"
-                    value="@org.formatAttendanceReportLatestDepartureTime()"
-                    @if(!org.show_attendance || !org.attendance_show_reports){ disabled }>
-            </td>
-        </tr>
-    </tbody></table></div>
+    <div class="depends-on-attendance-reports">
+        Charge a late fee of&nbsp;
+        $ <input type="number" min="0" max="999" name="attendance_report_late_fee"
+            value="@org.attendance_report_late_fee"
+            @if(!org.show_attendance || !org.attendance_show_reports){ disabled }>
+         &nbsp;per&nbsp;
+        <input type="number" min="0" max="999" name="attendance_report_late_fee_interval"
+            value="@org.attendance_report_late_fee_interval"
+            @if(!org.show_attendance || !org.attendance_show_reports){ disabled }>
+         &nbsp;minutes after&nbsp;
+        <input type="text" size="7" name="attendance_report_latest_departure_time"
+            value="@org.formatAttendanceReportLatestDepartureTime()"
+            @if(!org.show_attendance || !org.attendance_show_reports){ disabled }>
+    </div>
 
     <label>
         <input type="checkbox" name="attendance_show_percent" id="attendance-show-percent"

--- a/conf/evolutions/default/92.sql
+++ b/conf/evolutions/default/92.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+
+ALTER TABLE organization ADD COLUMN attendance_report_late_fee integer;
+ALTER TABLE organization ADD COLUMN attendance_report_late_fee_interval integer;
+
+# --- !Downs
+
+ALTER TABLE organization DROP COLUMN attendance_report_late_fee;
+ALTER TABLE organization DROP COLUMN attendance_report_late_fee_interval;


### PR DESCRIPTION
An update to the "late departures" attendance report:

1. Late departure events are now grouped by student for easier reading
2. The report now calculates the late fees owed, based on two new settings added to the Settings page