### PR TITLE
Weighted attendance rates

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -29,6 +29,8 @@ $(function() {
         $("a[href='#" + location.hash.substr(2) + "']").tab("show");
     }
 
+    $('[data-toggle="tooltip"]').tooltip();
+
     $("a[data-toggle='tab']").on("shown.bs.tab", function (e) {
         var hash = $(e.target).attr("href");
         if (hash.substr(0,1) == "#") {

--- a/app/assets/javascripts/settings_page.js
+++ b/app/assets/javascripts/settings_page.js
@@ -1,5 +1,4 @@
 export function init() {
-  $('[data-toggle="tooltip"]').tooltip();
 
   $('.has-dependents').each(function(i, el) {
     var checkboxWithDependents = $(el);

--- a/app/assets/stylesheets/main.less
+++ b/app/assets/stylesheets/main.less
@@ -401,6 +401,11 @@ body {
   text-align: center;
 }
 
+.attendance-weighted-value {
+    color: #ba44cc;
+    font-weight: bold;
+}
+
 td.attendance-error {
   font-size: 18px;
   text-align: center;
@@ -771,7 +776,11 @@ input.date {
   color: #aaa;
 }
 
-.settings-help-icon {
+.help-icon-wrapper {
+    font-weight: normal;
+}
+
+.help-icon {
   color: #aaa;
   font-size: 1.2em;
 

--- a/app/controllers/Attendance.java
+++ b/app/controllers/Attendance.java
@@ -58,15 +58,9 @@ public class Attendance extends Controller {
             next_date = null;
         }
 
-        Integer standard_time_frame_days = OrgConfig.get().org.attendance_rate_standard_time_frame;
-        Date standard_time_frame_start = Application.getDateFromString(Application.forDateInput(getAttendanceRateStandardTimeFrameStart()));
-        Date today = Application.getDateFromString(Application.forDateInput(new Date()));
-        boolean is_standard_time_frame = start_date.getTime() == standard_time_frame_start.getTime() && end_date.getTime() == today.getTime();
-
         return views.html.attendance_index.render(
             all_people, person_to_stats, all_codes, codes_map,
-            Application.attendancePeople(), start_date, end_date, is_custom_date, prev_date, next_date,
-            standard_time_frame_start, today, standard_time_frame_days, is_standard_time_frame
+            Application.attendancePeople(), start_date, end_date, is_custom_date, prev_date, next_date
         ).toString();
     }
 
@@ -721,20 +715,6 @@ public class Attendance extends Controller {
         }
 
         return person_to_stats;
-    }
-
-    public static Date getAttendanceRateStandardTimeFrameStart() {
-        Integer time_frame_days = OrgConfig.get().org.attendance_rate_standard_time_frame;
-        int count = 0;
-        Date start_date = Application.getStartOfYear();
-        Date end_date = new Date();
-        List<List<AttendanceDay>> school_days = listSchoolDays(start_date, end_date);
-
-        // if we run out of days before reaching time_frame_days, just return the start of the school year
-        if (time_frame_days == null || school_days.size() < time_frame_days) {
-            return start_date;
-        }
-        return school_days.get(time_frame_days - 1).get(0).day;
     }
 
     public static List<List<AttendanceDay>> listSchoolDays(Date start_date, Date end_date) {

--- a/app/controllers/Checkin.java
+++ b/app/controllers/Checkin.java
@@ -22,7 +22,7 @@ public class Checkin extends Controller {
     public Result checkinData(String time) throws ParseException {
         Date date = new SimpleDateFormat("M/d/yyyy, h:mm:ss a").parse(time);
 
-        Date start_date = Attendance.getAttendanceRateStandardTimeFrameStart();
+        Date start_date = Application.getStartOfYear();
         Date end_date = new Date();
         Map<Person, AttendanceStats> person_to_stats = Attendance.mapPeopleToStats(start_date, end_date);
 

--- a/app/models/AttendanceStats.java
+++ b/app/models/AttendanceStats.java
@@ -15,16 +15,38 @@ public class AttendanceStats {
     public Map<AttendanceCode, Integer> absence_counts =
         new HashMap<AttendanceCode, Integer>();
 
-    public void incrementCodeCount(AttendanceCode code) {
+    private Map<Integer, Double> values;
+
+    private double partial_day_value;
+
+    public AttendanceStats() {
+        values = new HashMap<>();
+        partial_day_value = 0;
+        if (OrgConfig.get().org.attendance_partial_day_value != null) {
+            partial_day_value = OrgConfig.get().org.attendance_partial_day_value.doubleValue();
+        }
+    }
+
+    public void processDay(AttendanceDay day, int index, Map<String, AttendanceCode> codes_map) {
+        if (day.code != null || day.start_time == null || day.end_time == null) {
+            incrementCodeCount(codes_map.get(day.code), index);
+        }
+        else {
+            incrementAttendance(day, index);
+        }
+    }
+
+    private void incrementCodeCount(AttendanceCode code, int index) {
         if (code == null) {
             return;
         }
-        // "no school" days do not count as absences
-        if (!code.code.equals("_NS_") && !code.not_counted) {
+        if (!code.not_counted) {
             if (code.counts_toward_attendance) {
                 approved_absences++;
+                values.put(index, 1d);
             } else {
                 unapproved_absences++;
+                values.put(index, 0d);
             }
         }
         if (!absence_counts.containsKey(code)) {
@@ -33,14 +55,16 @@ public class AttendanceStats {
         absence_counts.put(code, absence_counts.get(code) + 1);
     }
 
-    public void incrementAttendance(AttendanceDay day) {
+    private void incrementAttendance(AttendanceDay day, int index) {
         double hours = day.getHours();
         total_hours += hours;
 
         if (day.isPartial()) {
             partial_days_present++;
+            values.put(index, partial_day_value);
         } else {
             days_present++;
+            values.put(index, 1d);
         }
     }
 
@@ -49,14 +73,33 @@ public class AttendanceStats {
     }
 
     public double attendanceRate() {
-        double attendance_days = (double)days_present + approved_absences;
-        if (partial_days_present > 0) {
-            BigDecimal partial_day_value = OrgConfig.get().org.attendance_partial_day_value;
-            if (partial_day_value != null) {
-                attendance_days += (double)partial_days_present * partial_day_value.doubleValue();
-            }
+        double total = 0;
+        for (Map.Entry<Integer, Double> v : values.entrySet()) {
+            total += v.getValue();
         }
-        int total_days = days_present + partial_days_present + approved_absences + unapproved_absences;
-        return attendance_days / total_days;
+        return total / values.size();
+    }
+
+    public double weightedAttendanceRate() {
+        double total = 0;
+        for (Map.Entry<Integer, Double> v : values.entrySet()) {
+            Integer index = v.getKey();
+            Double value = v.getValue();
+            // The way the weighted attendance rate works is that the present day is worth 100%,
+            // and a long time in the past (i.e. several months ago) is worth close to 0%,
+            // with a smooth transition in between.
+            // reference_days is the number of school days in the past when the weight reaches 20%,
+            // so you can adjust this to stretch or compress the curve. I've chosen 60 because
+            // this is equivalent to 3 months. You could change it to e.g. 45 to make recent
+            // days weighted more as compared to older days.
+            double reference_days = 60d;
+            double curve_constant = Math.pow(5d/(4d * reference_days), 2);
+            // The curve is a Gaussian function, i.e. a bell curve, so near present day (index = 0)
+            // the weight decreases slowly at first, then faster, then reaches an inflection point
+            // and starts slowing down again, and finally has a long tail that goes out to infinity.
+            // Try graphing this function with a graphing app so you can visualize it.
+            total += value * Math.exp(-curve_constant * Math.pow(index, 2));
+        }
+        return total / values.size();
     }
 }

--- a/app/models/CheckinPerson.java
+++ b/app/models/CheckinPerson.java
@@ -19,7 +19,7 @@ public class CheckinPerson {
         name = person.getDisplayName();
 
         if (stats != null && OrgConfig.get().org.attendance_show_percent) {
-            double rate = stats.attendanceRate();
+            double rate = stats.weightedAttendanceRate();
             if (!Double.isNaN(rate)) {
                 attendance_rate = Attendance.formatAsPercent(rate);
             }

--- a/app/models/CheckinPerson.java
+++ b/app/models/CheckinPerson.java
@@ -18,7 +18,7 @@ public class CheckinPerson {
         pin = person.pin;
         name = person.getDisplayName();
 
-        if (stats != null && OrgConfig.get().org.attendance_show_percent) {
+        if (stats != null && OrgConfig.get().org.attendance_show_weighted_percent) {
             double rate = stats.weightedAttendanceRate();
             if (!Double.isNaN(rate)) {
                 attendance_rate = Attendance.formatAsPercent(rate);

--- a/app/models/Organization.java
+++ b/app/models/Organization.java
@@ -54,11 +54,11 @@ public class Organization extends Model {
     public Boolean attendance_show_reports;
     public Time attendance_report_latest_departure_time;
     public Boolean attendance_show_percent;
+    public Boolean attendance_show_weighted_percent;
     public Boolean attendance_enable_partial_days;
     public Time attendance_day_latest_start_time;
     public Double attendance_day_min_hours;
     public BigDecimal attendance_partial_day_value;
-    public Integer attendance_rate_standard_time_frame;
     public String attendance_admin_pin;
 
     @OneToMany(mappedBy="organization")
@@ -198,6 +198,11 @@ public class Organization extends Model {
             } else {
                 this.attendance_show_percent = false;
             }
+            if (values.containsKey("attendance_show_weighted_percent")) {
+                this.attendance_show_weighted_percent = Utils.getBooleanFromFormValue(values.get("attendance_show_weighted_percent")[0]);
+            } else {
+                this.attendance_show_weighted_percent = false;
+            }
             if (values.containsKey("attendance_enable_partial_days")) {
                 this.attendance_enable_partial_days = Utils.getBooleanFromFormValue(values.get("attendance_enable_partial_days")[0]);
             } else {
@@ -217,11 +222,6 @@ public class Organization extends Model {
                 this.attendance_partial_day_value = null;
             } else {
                 this.attendance_partial_day_value = new BigDecimal(values.get("attendance_partial_day_value")[0]);
-            }
-            if (!values.containsKey("attendance_rate_standard_time_frame") || values.get("attendance_rate_standard_time_frame")[0].isEmpty()) {
-                this.attendance_rate_standard_time_frame = null;
-            } else {
-                this.attendance_rate_standard_time_frame = Integer.parseInt(values.get("attendance_rate_standard_time_frame")[0]);
             }
             if (values.containsKey("attendance_day_latest_start_time")) {
                 this.attendance_day_latest_start_time = AttendanceDay.parseTime(values.get("attendance_day_latest_start_time")[0]);

--- a/app/views/attendance_code_form.scala.html
+++ b/app/views/attendance_code_form.scala.html
@@ -39,7 +39,7 @@ $(function() {
 
 @inputText(code_form("color"), '_label -> "Color", 'class -> "colorpicker")
 
-@if( OrgConfig.get().org.attendance_show_percent ) {
+@if( OrgConfig.get().org.attendance_show_percent || OrgConfig.get().org.attendance_show_weighted_percent ) {
 	@checkbox(code_form("counts_toward_attendance"), '_label -> "Counts toward attendance rate", 'class -> "absence-checkbox")
 	@checkbox(code_form("not_counted"), '_label -> "Neither counts toward nor against attendance rate", 'class -> "absence-checkbox")
 }

--- a/app/views/attendance_index.scala.html
+++ b/app/views/attendance_index.scala.html
@@ -97,6 +97,9 @@ $(function() {
 	<th width=100>Avg. hours per day</th>
 	@if( OrgConfig.get().org.attendance_show_percent ) {
 		<th width=100>Attendance Rate</th>
+		@if( !is_custom_date ) {
+			<th width=100>Weighted AR</th>
+		}
 	}
 	</thead>
 
@@ -135,6 +138,9 @@ $(function() {
 	<td align="center">@Attendance.format(person_to_stats.get(p).averageHoursPerDay())</td>
 	@if( OrgConfig.get().org.attendance_show_percent ) {
 		<td align="center">@Attendance.formatAsPercent(person_to_stats.get(p).attendanceRate())</td>
+		@if( !is_custom_date ) {
+			<td align="center">@Attendance.formatAsPercent(person_to_stats.get(p).weightedAttendanceRate())</td>
+		}
 	}
 }
 

--- a/app/views/attendance_index.scala.html
+++ b/app/views/attendance_index.scala.html
@@ -1,7 +1,6 @@
 @(people : List[Person], person_to_stats : Map[Person, AttendanceStats],
   codes : List[String], codes_map : Map[String, AttendanceCode], current_people: List[Person],
-  start_date: Date, end_date: Date, is_custom_date: Boolean, prev_date: Date, next_date: Date,
-  standard_time_frame_start: Date, today: Date, standard_time_frame_days: Integer, is_standard_time_frame: Boolean)
+  start_date: Date, end_date: Date, is_custom_date: Boolean, prev_date: Date, next_date: Date)
 
 @import helper._
 
@@ -56,11 +55,6 @@ $(function() {
 	    }
 	</p>
 }
-@if(standard_time_frame_days != null && !is_standard_time_frame) {
-	<p><a href="@routes.Attendance.index(Application.forDateInput(standard_time_frame_start), Application.forDateInput(today), true)">
-	 	Show last @standard_time_frame_days school days
-	</a></p>
-}
 <form method="GET">
 	<p>Showing
 		<input type="date" name="start_date" value="@Application.forDateInput(start_date)"> to
@@ -97,8 +91,17 @@ $(function() {
 	<th width=100>Avg. hours per day</th>
 	@if( OrgConfig.get().org.attendance_show_percent ) {
 		<th width=100>Attendance Rate</th>
+	}
+	@if( OrgConfig.get().org.attendance_show_weighted_percent ) {
 		@if( !is_custom_date ) {
-			<th width=100>Weighted AR</th>
+			<th width=100>
+				Weighted Att. Rate
+				<span class="help-icon-wrapper">
+					<span class="help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
+						title="Weighted attendance rate counts recent days as worth more, and distant past days as worth less, with a smooth transition in between. This is only computed for the full school year.">
+					</span>
+				</span>
+			</th>
 		}
 	}
 	</thead>
@@ -138,8 +141,12 @@ $(function() {
 	<td align="center">@Attendance.format(person_to_stats.get(p).averageHoursPerDay())</td>
 	@if( OrgConfig.get().org.attendance_show_percent ) {
 		<td align="center">@Attendance.formatAsPercent(person_to_stats.get(p).attendanceRate())</td>
+	}
+	@if( OrgConfig.get().org.attendance_show_weighted_percent ) {
 		@if( !is_custom_date ) {
-			<td align="center">@Attendance.formatAsPercent(person_to_stats.get(p).weightedAttendanceRate())</td>
+			<td align="center" class="attendance-weighted-value">
+				@Attendance.formatAsPercent(person_to_stats.get(p).weightedAttendanceRate())
+			</td>
 		}
 	}
 }

--- a/app/views/view_settings.scala.html
+++ b/app/views/view_settings.scala.html
@@ -135,16 +135,17 @@ the other way around.</p>
                @if(org.attendance_show_percent){ checked }>
         Show the "Attendance Rate" column
     </label>
-    &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
+    &nbsp;<span class="help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
         title="This allows you to see a person's attendance rate as a percentage of days present vs. total school days."></span>
-
-    <div>
-        Use the last
-        <input type="number" min="0" max="999" name="attendance_rate_standard_time_frame" value="@org.attendance_rate_standard_time_frame">
-        school days as the standard for calculating attendance rate
-        &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
-                    title="If a value is given here, the Check-in app will use this time frame to calculate attendance rate instead of using the whole school year. (The Check-in app shows a student's attendance rate when they check in.) A button will also be added to the Attendance By Year page to be able to easily view this time frame for all students."></span>
-    </div>
+    <br>
+    <label>
+        <input type="checkbox" name="attendance_show_weighted_percent" id="attendance-show-weighted-percent"
+               @if(org.attendance_show_weighted_percent){ checked }>
+        Show the "Weighted Attendance Rate" column
+    </label>
+    &nbsp;<span class="help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
+        title="Like the Attendance Rate column, except recent days are worth more while distant past days are worth less, with a smooth transition in between. If you are using the check-in app, this value will be shown to the student when they check in each day."></span>
+    <br>
     <label>
         <input type="checkbox" name="attendance_enable_partial_days" id="attendance-enable-partial-days"
                class="has-dependents" data-dependent-class="depends-on-partial-days"
@@ -157,7 +158,7 @@ the other way around.</p>
             <td>
                 <input type="text" size="7" name="attendance_day_latest_start_time" value="@org.formatAttendanceLatestStartTime()"
                        @if(!org.show_attendance || !org.attendance_enable_partial_days){ disabled }>
-                &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
+                &nbsp;<span class="help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
                     title="If a person arrives later than this time (e.g. 11:00), the day counts as a partial day regardless of how many hours the person was at school."></span>
             </td>
         </tr>
@@ -166,7 +167,7 @@ the other way around.</p>
             <td>
                 <input type="number" min="0" max="9" step="0.01" name="attendance_day_min_hours" value="@org.attendance_day_min_hours"
                        @if(!org.show_attendance || !org.attendance_enable_partial_days){ disabled }>
-                &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
+                &nbsp;<span class="help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
                     title="If a person is present for fewer than this number of hours (e.g. 5) in a day, it counts as a partial day."></span>
             </td>
         </tr>
@@ -176,7 +177,7 @@ the other way around.</p>
                 <input type="number" min="0" max="1" step="0.05" name="attendance_partial_day_value"
                        value="@org.attendance_partial_day_value"
                        @if(!org.show_attendance || !org.attendance_enable_partial_days){ disabled }>
-                &nbsp;<span class="settings-help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
+                &nbsp;<span class="help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
                     title="If the Attendance Rate column is enabled, you can decide how much value a partial day has in the percentage calculation. For example, if the value is 0.5, a partial day counts as half of a full day."></span>
             </td>
         </tr>

--- a/conf/evolutions/default/92.sql
+++ b/conf/evolutions/default/92.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+
+ALTER TABLE organization ADD COLUMN attendance_show_weighted_percent boolean NOT NULL DEFAULT(false);
+ALTER TABLE organization DROP COLUMN attendance_rate_standard_time_frame;
+
+# --- !Downs
+
+ALTER TABLE organization DROP COLUMN attendance_show_weighted_percent;
+ALTER TABLE organization ADD COLUMN attendance_rate_standard_time_frame integer;


### PR DESCRIPTION
This is a pretty significant change to the way attendance data is processed.

Goal: Add a new column to the annual attendance report called "Weighted Attendance Rate" which shows attendance rate weighted such that recent days are worth more and distant past days are worth less, with a smooth transition in between.

This column must be activated using a checkbox in Settings. If it is, the check-in app will display the weighted attendance rate to the student when they check in each day.

Values in the Weighted Attendance Rate column are colored purple. I did this because I was worried that users would get it mixed up with the regular Attendance Rate column, especially since Weighted AR is the rightmost column on the annual report but regular AR is the rightmost column on all other reports (since Weighted AR is only shown on the annual report).

Note: This replaces the feature I created a few months ago, "standard time frames", so I have deleted that feature. It was locked behind a feature flag, so can you check if anyone has that flag activated?

Note: Due to the new way attendance data is processed, we are no longer counting up instances of the "_NS_" (no school) code for display in the person report. _NS_ days are still listed in the list of days, but the total number of _NS_ days is not displayed at the top of the report. I think this is okay because it doesn't seem like useful information, and my reading of the code suggested it was only displayed incidentally, not intentionally. Let me know if I'm wrong.

I will be keeping my eyes open for miscalculations when looking at my school's live data.