### PR TITLE
Fix bug with bank cash balance report showing incorrect balances

### DIFF
--- a/app/models/TransactionList.java
+++ b/app/models/TransactionList.java
@@ -43,7 +43,7 @@ public class TransactionList {
 
   private BigDecimal getBalanceAsOfTransaction(Transaction transaction) {
     return transactions.stream()
-        .filter(t -> t.getId() <= transaction.getId())
+        .filter(t -> t.getDateCreated().getTime() <= transaction.getDateCreated().getTime())
         .map(t -> t.getAmount())
         .reduce(BigDecimal.ZERO, BigDecimal::add);
   }


### PR DESCRIPTION
In the Bank Cash Balance report, each row shows the current balance as of transaction. This value was calculated based on transactions sorted by ID rather than date.