### PR TITLE
Earliest departure time

### DIFF
--- a/app/controllers/Attendance.java
+++ b/app/controllers/Attendance.java
@@ -903,6 +903,7 @@ public class Attendance extends Controller {
     Form<AttendanceRule> form = mFormFactory.form(AttendanceRule.class);
     Form<AttendanceRule> filledForm = form.bindFromRequest(request);
     AttendanceRule.save(filledForm, Utils.getOrg(request));
+    CachedPage.onAttendanceChanged(Utils.getOrg(request));
     return redirect(routes.Attendance.rules());
   }
 

--- a/app/controllers/CachedPage.java
+++ b/app/controllers/CachedPage.java
@@ -110,4 +110,8 @@ public abstract class CachedPage {
     remove(RECENT_COMMENTS, org);
     Utils.updateCustodia();
   }
+
+  public static void onAttendanceChanged(Organization org) {
+    remove(ATTENDANCE_INDEX, org);
+  }
 }

--- a/app/views/attendance_edit_rule.scala.html
+++ b/app/views/attendance_edit_rule.scala.html
@@ -88,7 +88,14 @@ enable_late_fees : Boolean
 					Latest Arrival Time
 					<span class="help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip" title="If set, this will be used as the latest arrival time allowed for a full day instead of the default time configured in Settings."></span>
 				</th>
-				<td><input type="text" size="10" name="_latestStartTime" value="@rule.getFormattedTime(rule.getLatestStartTime())"></td>
+				<td><input type="text" class="js-time" size="10" name="_latestStartTime" value="@rule.getFormattedTime(rule.getLatestStartTime())"></td>
+			</tr>
+			<tr>
+				<th>
+					Earliest Departure Time
+					<span class="help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip" title="If set, this will be used as the earliest departure time allowed for a full day instead of the default time configured in Settings."></span>
+				</th>
+				<td><input type="text" class="js-time" size="10" name="_earliestDepartureTime" value="@rule.getFormattedTime(rule.getEarliestDepartureTime())"></td>
 			</tr>
 		}
 		@if(enable_late_fees) {

--- a/app/views/attendance_rules_table.scala.html
+++ b/app/views/attendance_rules_table.scala.html
@@ -21,6 +21,7 @@ enable_late_fees : Boolean
 			@if(enable_partial_days) {
 				<th>Min Hours</th>
 				<th>Latest Arrival Time</th>
+				<th>Earliest Departure Time</th>
 			}
 			@if(enable_late_fees) {
 				<th>Exempt from Fees</th>
@@ -38,6 +39,7 @@ enable_late_fees : Boolean
 				@if(enable_partial_days) {
 					<td>@rule.getMinHours()</td>
 					<td>@rule.getFormattedTime(rule.getLatestStartTime())</td>
+					<td>@rule.getFormattedTime(rule.getEarliestDepartureTime())</td>
 				}
 				@if(enable_late_fees) {
 					<td>@rule.getFormattedBoolean(rule.getExemptFromFees())</td>

--- a/app/views/view_settings.scala.html
+++ b/app/views/view_settings.scala.html
@@ -175,6 +175,15 @@ the other way around.</p>
     </label>
     <div class="depends-on-partial-days"><table><tbody>
         <tr>
+            <td>Minimum hours for a full day</td>
+            <td>
+                <input type="number" min="0" max="9" step="0.01" name="attendanceDayMinHours" value="@org.getAttendanceDayMinHours()"
+                       @if(!org.getShowAttendance() || !org.getAttendanceEnablePartialDays()){ disabled }>
+                &nbsp;<span class="help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
+                    title="If a person is present for fewer than this number of hours (e.g. 5) in a day, it counts as a partial day."></span>
+            </td>
+        </tr>
+        <tr>
             <td>Latest arrival time allowed for a full day</td>
             <td>
                 <input type="time" size="7" name="attendanceDayLatestStartTime" value="@org.formatAttendanceLatestStartTime()"
@@ -184,12 +193,12 @@ the other way around.</p>
             </td>
         </tr>
         <tr>
-            <td>Minimum hours for a full day</td>
+            <td>Earliest departure time allowed for a full day</td>
             <td>
-                <input type="number" min="0" max="9" step="0.01" name="attendanceDayMinHours" value="@org.getAttendanceDayMinHours()"
+                <input type="time" size="7" name="attendanceDayEarliestDepartureTime" value="@org.formatAttendanceEarliestDepartureTime()"
                        @if(!org.getShowAttendance() || !org.getAttendanceEnablePartialDays()){ disabled }>
                 &nbsp;<span class="help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
-                    title="If a person is present for fewer than this number of hours (e.g. 5) in a day, it counts as a partial day."></span>
+                    title="If a person leaves earlier than this time, the day counts as a partial day regardless of how many hours the person was at school."></span>
             </td>
         </tr>
         <tr>

--- a/conf/evolutions/default/96.sql
+++ b/conf/evolutions/default/96.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+
+ALTER TABLE organization ADD COLUMN attendance_day_earliest_departure_time time;
+ALTER TABLE attendance_rule ADD COLUMN earliest_departure_time time;
+
+# --- !Downs
+
+ALTER TABLE organization DROP COLUMN attendance_day_earliest_departure_time;
+ALTER TABLE attendance_rule DROP COLUMN earliest_departure_time;

--- a/modelsLibrary/app/models/AttendanceDay.java
+++ b/modelsLibrary/app/models/AttendanceDay.java
@@ -144,7 +144,8 @@ public class AttendanceDay extends Model {
       if (latest_start_time != null && startTime.getTime() > latest_start_time.getTime()) {
         return true;
       }
-      if (earliest_departure_time != null && endTime.getTime() < earliest_departure_time.getTime()) {
+      if (earliest_departure_time != null
+          && endTime.getTime() < earliest_departure_time.getTime()) {
         return true;
       }
     }

--- a/modelsLibrary/app/models/AttendanceDay.java
+++ b/modelsLibrary/app/models/AttendanceDay.java
@@ -120,6 +120,7 @@ public class AttendanceDay extends Model {
     if (org.getAttendanceEnablePartialDays()) {
       Double min_hours = org.getAttendanceDayMinHours();
       Time latest_start_time = org.getAttendanceDayLatestStartTime();
+      Time earliest_departure_time = org.getAttendanceDayEarliestDepartureTime();
 
       List<AttendanceRule> rules =
           AttendanceRule.currentRules(day, person.getPersonId(), person.getOrganization());
@@ -131,6 +132,9 @@ public class AttendanceDay extends Model {
           if (rule.getLatestStartTime() != null) {
             latest_start_time = rule.getLatestStartTime();
           }
+          if (rule.getEarliestDepartureTime() != null) {
+            earliest_departure_time = rule.getEarliestDepartureTime();
+          }
         }
       }
 
@@ -138,6 +142,9 @@ public class AttendanceDay extends Model {
         return true;
       }
       if (latest_start_time != null && startTime.getTime() > latest_start_time.getTime()) {
+        return true;
+      }
+      if (earliest_departure_time != null && endTime.getTime() < earliest_departure_time.getTime()) {
         return true;
       }
     }

--- a/modelsLibrary/app/models/AttendanceRule.java
+++ b/modelsLibrary/app/models/AttendanceRule.java
@@ -44,6 +44,7 @@ public class AttendanceRule extends Model {
   private Double minHours;
 
   private Time latestStartTime;
+  private Time earliestDepartureTime;
 
   private boolean exemptFromFees;
 
@@ -139,6 +140,15 @@ public class AttendanceRule extends Model {
         rule.setLatestStartTime(AttendanceDay.parseTime(latest_start_time));
       } else {
         rule.setLatestStartTime(null);
+      }
+    }
+
+    if (form.field("_earliestDepartureTime").value().isPresent()) {
+      String earliest_departure_time = form.field("_earliestDepartureTime").value().get();
+      if (!earliest_departure_time.isEmpty()) {
+        rule.setEarliestDepartureTime(AttendanceDay.parseTime(earliest_departure_time));
+      } else {
+        rule.setEarliestDepartureTime(null);
       }
     }
 

--- a/modelsLibrary/app/models/Organization.java
+++ b/modelsLibrary/app/models/Organization.java
@@ -49,6 +49,7 @@ public class Organization extends Model {
   private Boolean attendanceShowWeightedPercent;
   private Boolean attendanceEnablePartialDays;
   private Time attendanceDayLatestStartTime;
+  private Time attendanceDayEarliestDepartureTime;
   private Double attendanceDayMinHours;
   private BigDecimal attendancePartialDayValue;
   private String attendanceAdminPin;
@@ -69,6 +70,10 @@ public class Organization extends Model {
 
   public String formatAttendanceLatestStartTime() {
     return formatTime(attendanceDayLatestStartTime);
+  }
+
+  public String formatAttendanceEarliestDepartureTime() {
+    return formatTime(attendanceDayEarliestDepartureTime);
   }
 
   public String formatAttendanceReportLatestDepartureTime() {
@@ -182,6 +187,12 @@ public class Organization extends Model {
             AttendanceDay.parseTime(values.get("attendanceDayLatestStartTime")[0]);
       } else {
         this.attendanceDayLatestStartTime = null;
+      }
+      if (values.containsKey("attendanceDayEarliestDepartureTime")) {
+        this.attendanceDayEarliestDepartureTime =
+            AttendanceDay.parseTime(values.get("attendanceDayEarliestDepartureTime")[0]);
+      } else {
+        this.attendanceDayEarliestDepartureTime = null;
       }
       if (values.containsKey("attendanceReportLatestDepartureTime")) {
         this.attendanceReportLatestDepartureTime =


### PR DESCRIPTION
Add "earliest allowed departure time" to Settings and Attendance Rule. This affects how attendance rates are calculated.

I also made it so the cache for the Attendance home page is cleared whenever an Attendance Rule changes.