### PR TITLE
Checkin updates

### DIFF
--- a/app/controllers/Checkin.java
+++ b/app/controllers/Checkin.java
@@ -29,7 +29,8 @@ public class Checkin extends Controller {
     Map<Person, AttendanceStats> person_to_stats =
         Attendance.mapPeopleToStats(start_date, end_date, organization);
 
-    boolean show_weighted_percent = organization.getAttendanceShowWeightedPercent();
+    boolean show_attendance_rate = organization.getAttendanceShowRateInCheckin();
+    boolean use_weighted_attendance_rate = organization.getAttendanceShowWeightedPercent();
 
     List<CheckinPerson> people =
         Application.attendancePeople(organization).stream()
@@ -41,7 +42,8 @@ public class Checkin extends Controller {
                         p,
                         AttendanceDay.findCurrentDay(date, p.getPersonId(), organization),
                         person_to_stats.get(p),
-                        show_weighted_percent))
+                        show_attendance_rate,
+                        use_weighted_attendance_rate))
             .collect(Collectors.toList());
 
     // add admin
@@ -49,7 +51,7 @@ public class Checkin extends Controller {
     admin.setPersonId(-1);
     admin.setFirstName("Admin");
     admin.setPin(organization.getAttendanceAdminPin());
-    people.add(0, new CheckinPerson(admin, null, null, show_weighted_percent));
+    people.add(0, new CheckinPerson(admin, null, null, show_attendance_rate, use_weighted_attendance_rate));
 
     List<String> absence_codes =
         AttendanceCode.all(organization).stream()

--- a/app/models/CheckinPerson.java
+++ b/app/models/CheckinPerson.java
@@ -16,13 +16,14 @@ public class CheckinPerson {
       Person person,
       AttendanceDay current_day,
       AttendanceStats stats,
-      boolean show_weighted_percent) {
+      boolean show_attendance_rate,
+      boolean use_weighted_attendance_rate) {
     personId = person.getPersonId();
     pin = person.getPin();
     name = person.getDisplayName();
 
-    if (stats != null && show_weighted_percent) {
-      double rate = stats.weightedAttendanceRate();
+    if (stats != null && show_attendance_rate) {
+      double rate = use_weighted_attendance_rate ? stats.weightedAttendanceRate() : stats.attendanceRate();
       if (!Double.isNaN(rate)) {
         attendance_rate = ModelUtils.formatAsPercent(rate);
       }

--- a/app/views/view_settings.scala.html
+++ b/app/views/view_settings.scala.html
@@ -109,6 +109,11 @@ the other way around.</p>
         "@Utils.getOrgConfig(request).org.getShortName()" (case-sensitive). To reset the password, enter a new one here:
         <br>
         <input type="text" size="30" placeholder="New password" name="electronic_signin_password" />
+        <br>
+        Have the app automatically assign absence code
+        <input size="7" type="text" name="attendanceDefaultAbsenceCode" value="@org.getAttendanceDefaultAbsenceCode()">
+        if someone doesn't sign in by
+        <input type="time" size="7" name="attendanceDefaultAbsenceCodeTime" value="@org.getAttendanceDefaultAbsenceCodeTime()">
     </p>
 
     <label>

--- a/app/views/view_settings.scala.html
+++ b/app/views/view_settings.scala.html
@@ -165,7 +165,15 @@ the other way around.</p>
         Show the "Weighted Attendance Rate" column
     </label>
     &nbsp;<span class="help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
-        title="Like the Attendance Rate column, except recent days are worth more while distant past days are worth less, with a smooth transition in between. If you are using the check-in app, this value will be shown to the student when they check in each day."></span>
+        title="Like the Attendance Rate column, except recent days are worth more while distant past days are worth less, with a smooth transition in between."></span>
+    <br>
+    <label>
+        <input type="checkbox" name="attendanceShowRateInCheckin" id="attendance-show-rate-in-checkin"
+               @if(org.getAttendanceShowRateInCheckin()){ checked }>
+        Show student's attendance rate to them when they use the electronic check-in app
+    </label>
+    &nbsp;<span class="help-icon glyphicon glyphicon-info-sign" data-toggle="tooltip"
+        title='If you are using the electronic check-in app, this will show each student their own attendance rate when they sign in each day. If the checkbox "Show the Weighted Attendance Rate column" is checked, weighted attendance rate will be used; otherwise normal attendance rate will be used.'></span>
     <br>
     <label>
         <input type="checkbox" name="attendanceEnablePartialDays" id="attendance-enable-partial-days"

--- a/app/views/view_settings.scala.html
+++ b/app/views/view_settings.scala.html
@@ -102,7 +102,7 @@ the other way around.</p>
         <input type="checkbox" name="showElectronicSignin"
             @if(org.getShowElectronicSignin()){ checked }
             class="has-dependents" data-dependent-class="depends-on-electronic-signin">
-        Enable the experimental electronic check-in app (new in Fall 2019)
+        Enable the electronic check-in app
     </label>
 
     <p class="depends-on-electronic-signin">The <a target="_blank" href="@routes.Public.checkin()">electronic check-in app</a> username is

--- a/conf/evolutions/default/100.sql
+++ b/conf/evolutions/default/100.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+
+ALTER TABLE organization ADD COLUMN attendance_default_absence_code text;
+ALTER TABLE organization ADD COLUMN attendance_default_absence_code_time time;
+
+# --- !Downs
+
+ALTER TABLE organization DROP COLUMN attendance_default_absence_code;
+ALTER TABLE organization DROP COLUMN attendance_default_absence_code_time;

--- a/conf/evolutions/default/99.sql
+++ b/conf/evolutions/default/99.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+
+ALTER TABLE organization ADD COLUMN attendance_show_rate_in_checkin boolean NOT NULL DEFAULT(false);
+
+# --- !Downs
+
+ALTER TABLE organization DROP COLUMN attendance_show_rate_in_checkin;

--- a/modelsLibrary/app/models/Organization.java
+++ b/modelsLibrary/app/models/Organization.java
@@ -55,6 +55,8 @@ public class Organization extends Model {
   private Double attendanceDayMinHours;
   private BigDecimal attendancePartialDayValue;
   private String attendanceAdminPin;
+  private String attendanceDefaultAbsenceCode;
+  private Time attendanceDefaultAbsenceCodeTime;
 
   private String rolesIndividualTerm;
   private String rolesCommitteeTerm;
@@ -256,6 +258,17 @@ public class Organization extends Model {
       } else {
         this.attendanceReportLateFeeInterval_2 =
             Integer.parseInt(values.get("attendanceReportLateFeeInterval_2")[0]);
+      }
+      if (values.containsKey("attendanceDefaultAbsenceCode")) {
+        this.attendanceDefaultAbsenceCode = values.get("attendanceDefaultAbsenceCode")[0];
+      } else {
+        this.attendanceDefaultAbsenceCode = null;
+      }
+      if (values.containsKey("attendanceDefaultAbsenceCodeTime")) {
+        this.attendanceDefaultAbsenceCodeTime =
+            AttendanceDay.parseTime(values.get("attendanceDefaultAbsenceCodeTime")[0]);
+      } else {
+        this.attendanceDefaultAbsenceCodeTime = null;
       }
     }
     if (values.containsKey("accounting_settings")) {

--- a/modelsLibrary/app/models/Organization.java
+++ b/modelsLibrary/app/models/Organization.java
@@ -48,6 +48,7 @@ public class Organization extends Model {
   private Integer attendanceReportLateFeeInterval_2;
   private Boolean attendanceShowPercent;
   private Boolean attendanceShowWeightedPercent;
+  private Boolean attendanceShowRateInCheckin;
   private Boolean attendanceEnablePartialDays;
   private Time attendanceDayLatestStartTime;
   private Time attendanceDayEarliestDepartureTime;
@@ -175,6 +176,12 @@ public class Organization extends Model {
             ModelUtils.getBooleanFromFormValue(values.get("attendanceShowWeightedPercent")[0]);
       } else {
         this.attendanceShowWeightedPercent = false;
+      }
+      if (values.containsKey("attendanceShowRateInCheckin")) {
+        this.attendanceShowRateInCheckin =
+            ModelUtils.getBooleanFromFormValue(values.get("attendanceShowRateInCheckin")[0]);
+      } else {
+        this.attendanceShowRateInCheckin = false;
       }
       if (values.containsKey("attendanceEnablePartialDays")) {
         this.attendanceEnablePartialDays =


### PR DESCRIPTION
- Make it configurable to show the student's attendance rate when they sign in on the check-in app (previously it always showed)
- Remove text in Settings that says the check-in app is experimental
- Enable check-in app to automatically assign an absence code if someone doesn't sign in by a certain time