### PR TITLE
Fix Custodia excused day highlighting

### DIFF
--- a/custodia/src/js/heatmap.jsx
+++ b/custodia/src/js/heatmap.jsx
@@ -36,7 +36,6 @@ module.exports = class Heatmap extends React.Component {
     const sortedDates = Object.keys(groupedDays).sort();
 
     let i = 0;
-    let temparray;
     const maps = [];
     while (i < sortedDates.length) {
       // Find up to four months worth of dates, which we will send
@@ -47,13 +46,13 @@ module.exports = class Heatmap extends React.Component {
         j++;
       }
 
-      temparray = sortedDates.slice(i, j);
-      i = j;
-      const dates = temparray
+      const dates = sortedDates
+        .slice(i, j)
         .map(function (d) {
           return groupedDays[d];
         })
         .concatAll();
+      i = j;
 
       maps.push(<Heatmapmonth key={i} index={i} requiredMinutes={minutes} days={dates} />);
     }

--- a/custodia/src/js/heatmapmonth.jsx
+++ b/custodia/src/js/heatmapmonth.jsx
@@ -21,19 +21,11 @@ class HeatmapMonth extends React.Component {
     return formatted;
   };
 
-  getHighlights = (days, requiredMinutes) => {
-    const hights = [];
-    days.forEach(function (day) {
-      if (day.excused) {
-        hights.push(dayjs(day.day).toDate());
-      }
-    });
-    return hights;
-  };
+  getHighlights = (days) => days.filter((day) => day.excused).map((day) => dayjs(day.day).toDate());
 
   loadHeatmap = () => {
     const data = this.formatDays(this.props.days, this.props.requiredMinutes);
-    const highlight = this.getHighlights(this.props.days, this.props.requiredMinutes);
+    const highlight = this.getHighlights(this.props.days);
 
     const doUpdate = this.map !== null;
     if (!doUpdate) {
@@ -53,6 +45,7 @@ class HeatmapMonth extends React.Component {
     };
     if (doUpdate) {
       this.map.update(data);
+      this.map.highlight(highlight);
     } else {
       this.map.init({
         itemSelector: selector,

--- a/django/custodia/templates/index.html
+++ b/django/custodia/templates/index.html
@@ -28,7 +28,8 @@
     <link href="/django-static/css/bootstrap.min.css?v=2" rel="stylesheet">
     <link href="/django-static/css/bootstrap-theme.min.css?v=2" rel="stylesheet">
 
-    <link href="/django-static/starter-template.css" rel="stylesheet">
+    <!-- v=3 is here to manually bust the cache -->
+    <link href="/django-static/starter-template.css?v=3" rel="stylesheet">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
 </head>
 <body>

--- a/django/static/starter-template.css
+++ b/django/static/starter-template.css
@@ -118,8 +118,9 @@ a {
         width: 1300px;
     }
 }
-rect.highlight {
+rect.highlight, rect.highlight-now {
     fill: orange !important;
+    stroke: #444 !important;
 }
 
 .graph-rect {


### PR DESCRIPTION
![Screenshot 2025-04-10 at 4 43 46 PM](https://github.com/user-attachments/assets/deeb311e-ff50-41ca-8aac-d1686e66fb42)

Excused days (highlighted in orange) now update their coloring immediately when you check/uncheck the "excused" checkbox. 

Excused days are now highlighted orange even if they are the current day

One bug remains which is that if you uncheck "excused" from a day so that there are now no excused days, then the orange highlight doesn't go away until you select a different day. 